### PR TITLE
Corrixese un erro no formato gift das preguntas de SBD

### DIFF
--- a/big_data_aplicado/IGB/bda_igb.gift
+++ b/big_data_aplicado/IGB/bda_igb.gift
@@ -1,0 +1,19 @@
+:: Q1
+:: Cual es el componente que no forma parte da aquitectura de flume {
+    = Ipyevents
+    ~ Sinks
+    ~ Channels
+    ~ Agent
+}
+
+:: Q2
+:: Las siglas ETL dentro de la arquitectura de Datawarehouse se refiere a la extracción, carga y análisis de los datos {F}
+
+:: Q3
+:: Los esquemas más utilizados para el acceso rápido a la información en BBDD relacionales son Star Schema y Snowflake {T}
+
+:: Q4
+:: Un Data Lake almacena información estructurada y un Data Mart puede almacenar información no estructurada también {F}
+
+:: Q5
+:: La técnica de sharding consiste en dividir los datos en diferentes nodos del cluster y la replicación consiste en la división de los datos en conjuntos más pequeños {F}

--- a/sistemas_big_data/IGB/sbd_igb.gift
+++ b/sistemas_big_data/IGB/sbd_igb.gift
@@ -2,7 +2,7 @@
 :: Los archivos parquet tienen formato binario y almacenan datos no estructurados {F}
 
 :: Q2
-:: Los archivos CSV son ficheros de texto plano que se pueden separar por /":" por ejemplo {T}
+:: Los archivos CSV son ficheros de texto plano que se pueden separar por "\:" por ejemplo {T}
 
 :: Q3
 :: Características que debe de cumplir un portal OpenData (señala la incorrecta) {

--- a/sistemas_big_data/IGB/sbd_igb.gift
+++ b/sistemas_big_data/IGB/sbd_igb.gift
@@ -1,0 +1,24 @@
+:: Q1
+:: Los archivos parquet tienen formato binario y almacenan datos no estructurados {F}
+
+:: Q2
+:: Los archivos CSV son ficheros de texto plano que se pueden separar por ":" por ejemplo {T}
+
+:: Q3
+:: Características que debe de cumplir un portal OpenData (señala la incorrecta) {
+    ~ Continuidad
+    ~ Formatos abiertos, editables
+    ~ Origen de los datos documentada
+    = Con licencias de copyright
+}
+
+:: Q4
+:: Para acceder a los datos del portal OpenData del gobierno de españa podemos utilizar diferentes medios, cual de los siguientes no sería válido? {
+    ~ Scrapping
+    ~ APIs
+    ~ Descarga de los datos navegando por la página
+    = Data Mining
+}
+
+:: Q5
+:: Para hacer un pull request debemos de hacer primero un fork al repositorio que queramos cambiar luego, clonarlo, hacer los cambios en local y subirlos {T}

--- a/sistemas_big_data/IGB/sbd_igb.gift
+++ b/sistemas_big_data/IGB/sbd_igb.gift
@@ -2,7 +2,7 @@
 :: Los archivos parquet tienen formato binario y almacenan datos no estructurados {F}
 
 :: Q2
-:: Los archivos CSV son ficheros de texto plano que se pueden separar por ":" por ejemplo {T}
+:: Los archivos CSV son ficheros de texto plano que se pueden separar por /":" por ejemplo {T}
 
 :: Q3
 :: Características que debe de cumplir un portal OpenData (señala la incorrecta) {


### PR DESCRIPTION
Corrixese un erro no formato gift das preguntas de SBD, o erro debíase aos caracteres especiais : que teñen que ir precedidos de \